### PR TITLE
Escape usernames in leaderboard

### DIFF
--- a/cogs/leaderboard.py
+++ b/cogs/leaderboard.py
@@ -1,6 +1,7 @@
 from discord.ext import commands
 from discord import Embed, Member, File
 from discord.channel import TextChannel
+from discord.utils import escape_markdown
 
 import re
 import logging
@@ -234,7 +235,7 @@ class Leaderboard(commands.Cog):
                         medal=self.get_medal(i + 1),
                         count=right_justify(row["count"], len(
                             str(rows1[0]["count"])), "\u2063 "),
-                        author=f'**{row["author"]}**'
+                        author=f'**{escape_markdown(row["author"])}**'
                         if row["author_id"] == (
                             author.id if not member else member.id)
                         else
@@ -251,7 +252,7 @@ class Leaderboard(commands.Cog):
                     medal=self.get_medal(row["row_number"]),
                     count=right_justify(row["count"], len(
                         str(rows1[0]["count"])), "\u2063 "),
-                    author=(f'**{row["author"]}**'
+                    author=(f'**{escape_markdown(row["author"])}**'
                             if row["author_id"] == (
                                 author.id if not member else member.id)
                             else

--- a/core/bot.py
+++ b/core/bot.py
@@ -48,7 +48,7 @@ class LoggingHandler(logging.StreamHandler):
 
 
 class MasarykBot(Bot):
-    def __init__(self, *args, activity=Game(name="Commands: !help"), **kwargs):
+    def __init__(self, *args, activity=Game(name=f"Commands: {os.getenv('PREFIX')}help"), **kwargs):
         super().__init__(*args, **kwargs)
 
         self.ininial_params = args, kwargs


### PR DESCRIPTION
Usernames in leaderboard embed are markdown escaped.
Presence uses environment prefix instead of hardcoded "!".