### PR TITLE
fix styling inconsistencies: black color of colorbar labels

### DIFF
--- a/bot/cogs/utils/heatmap.py
+++ b/bot/cogs/utils/heatmap.py
@@ -27,7 +27,7 @@ GITHUB_CMAP = ListedColormap(
     [
         [0.09, 0.11, 0.13, 1],
         [0.05, 0.27, 0.16, 1],
-        [0.22, 0.83, 0.33, 1],
+        [0.00, 0.43, 0.20, 1],
         [0.15, 0.65, 0.25, 1],
         [0.22, 0.83, 0.33, 1],
     ]
@@ -66,14 +66,14 @@ def plot_heatmap(series: pd.Series, cmap: Optional[str] = None) -> plt.Axes:
 
     ax.set_xticks(list(ticks.keys()))
     ax.set_xticklabels(list(ticks.values()))
-    ax.tick_params(axis="x", colors="white")
     ax.xaxis.tick_top()
 
     ax.set_yticks(range(len(DAYS)))
     ax.set_yticklabels(reversed(DAYS))
-    ax.tick_params(axis="y", colors="white")
     for label in ax.yaxis.get_ticklabels()[::2]:
         label.set_visible(False)
+
+    plt.rcParams.update({"ytick.color": "white", "xtick.color": "white"})
 
     plt.sca(ax)
     plt.sci(mesh)


### PR DESCRIPTION
before
![2022-02-11_21-13_1](https://user-images.githubusercontent.com/63084369/153663462-8c6b9fcc-c3c8-4d62-a9b2-ef267394ad86.png)
after
![2022-02-11_21-13](https://user-images.githubusercontent.com/63084369/153663485-a623c2bf-0a3f-497a-a4db-7218c9380ee4.png)

